### PR TITLE
Add delaySync and dealyMetaSync functions.

### DIFF
--- a/src/Database/LMDB/Simple/DBRef.hs
+++ b/src/Database/LMDB/Simple/DBRef.hs
@@ -63,18 +63,18 @@ readDBRef ref@(Ref env dbi key) = transaction env (tx env ref)
 
   where tx :: Serialise a
            => Environment mode -> DBRef mode a -> Transaction ReadOnly (Maybe a)
-        tx (Env env) _ = getBS (Db env dbi) key
+        tx (Env env _ _) _ = getBS (Db env dbi) key
 
 -- | Write a new value into a 'DBRef'.
 writeDBRef :: Serialise a => DBRef ReadWrite a -> Maybe a -> IO ()
 writeDBRef (Ref env dbi key) = transaction env . maybe (delKey env) (putKey env)
 
   where delKey :: Environment ReadWrite -> Transaction ReadWrite ()
-        delKey (Env env) = void $ deleteBS (Db env dbi) key
+        delKey (Env env _ _) = void $ deleteBS (Db env dbi) key
 
         putKey :: Serialise a
                => Environment ReadWrite -> a -> Transaction ReadWrite ()
-        putKey (Env env) = putBS (Db env dbi) key
+        putKey (Env env _ _) = putBS (Db env dbi) key
 
 -- | Atomically mutate the contents of a 'DBRef'.
 modifyDBRef_ :: Serialise a => DBRef ReadWrite a -> (Maybe a -> Maybe a) -> IO ()
@@ -88,7 +88,7 @@ modifyDBRef (Ref env dbi key) = transaction env . tx env
   where tx :: Serialise a
            => Environment mode -> (Maybe a -> (Maybe a, b))
            -> Transaction ReadWrite b
-        tx (Env env) f = let db = Db env dbi in
+        tx (Env env _ _) f = let db = Db env dbi in
           getBS db key >>= \x -> let (x', r) = f x in
           maybe (void $ deleteBS db key) (putBS db key) x' >>
           return r

--- a/test/Database/LMDB/SimpleSpec.hs
+++ b/test/Database/LMDB/SimpleSpec.hs
@@ -62,3 +62,27 @@ spec = beforeAll setup $ do
       ( do nestTransaction (put db 3 $ Just "three")
            get db 3
       ) `shouldReturn` Just "three"
+
+  describe "delaySync" $ do
+    it "sets the MDB_NOSYNC flag to on" $ \(env, _) ->
+      delaySync env $ (isSyncDelayed env) `shouldReturn` True
+    it "clears MDB_NOSYNC flag after the action completes" $ \(env, _) ->
+      (delaySync env (return ()) >> isSyncDelayed env) `shouldReturn` False
+    it "doesn't clear MDB_NOSYNC in a nested delaySync call" $ \(env, _) ->
+      (delaySync env $ delaySync env (return ()) >> isSyncDelayed env)
+      `shouldReturn` True
+    it "clears the MDB_NOSYNC flag after an action with a nested syncDelay call ends" $ \(env, _) ->
+      (delaySync env (delaySync env $ return ()) >> isSyncDelayed env)
+      `shouldReturn` False
+
+  describe "delayMetaSync" $ do
+    it "sets the MDB_NOMETASYNC flag to on" $ \(env, _) ->
+      delayMetaSync env $ (isMetaSyncDelayed env) `shouldReturn` True
+    it "clears MDB_NOMETASYNC flag after the action completes" $ \(env, _) ->
+      (delayMetaSync env (return ()) >> isMetaSyncDelayed env) `shouldReturn` False
+    it "doesn't clear MDB_NOMETASYNC in a nested delaySync call" $ \(env, _) ->
+      (delayMetaSync env $ delayMetaSync env (return ()) >> isMetaSyncDelayed env)
+      `shouldReturn` True
+    it "clears the MDB_NONETASYNC flag after an action with a nested syncDelay call ends" $ \(env, _) ->
+      (delayMetaSync env (delayMetaSync env $ return ()) >> isMetaSyncDelayed env)
+      `shouldReturn` False


### PR DESCRIPTION
Please take a look of this variant for the pull request #2 with `delaySync` and `delayMetaSync` functions. I had to change the `Environment` definition to take into account calls to these functions in a multithreaded environment or in nested contents.