### PR TITLE
Adds `closeEnvironment` function.

### DIFF
--- a/src/Database/LMDB/Simple.hs
+++ b/src/Database/LMDB/Simple.hs
@@ -50,6 +50,7 @@ module Database.LMDB.Simple
   , Limits (..)
   , defaultLimits
   , openEnvironment
+  , closeEnvironment
   , openReadWriteEnvironment
   , openReadOnlyEnvironment
   , readOnlyEnvironment
@@ -104,6 +105,7 @@ import Database.LMDB.Raw
   , MDB_EnvFlag (MDB_NOSUBDIR, MDB_RDONLY)
   , MDB_DbFlag (MDB_CREATE)
   , mdb_env_create
+  , mdb_env_close
   , mdb_env_open
   , mdb_env_set_mapsize
   , mdb_env_set_maxdbs
@@ -205,6 +207,11 @@ openEnvironment path limits = do
         isNotDirectoryError LMDB_Error { e_code = Left code }
           | Errno (fromIntegral code) == eNOTDIR = True
         isNotDirectoryError _                    = False
+
+-- | Closes an open envrionment. After calling this function, the
+-- environment should *not* be used again.
+closeEnvironment :: Mode mode => Environment mode -> IO ()
+closeEnvironment (Env mdb_env) = runInBoundThread $ mdb_env_close mdb_env
 
 -- | Convenience function for opening an LMDB environment in 'ReadWrite'
 -- mode; see 'openEnvironment'

--- a/test/Database/LMDB/SimpleSpec.hs
+++ b/test/Database/LMDB/SimpleSpec.hs
@@ -10,7 +10,7 @@ import Harness
 import Test.Hspec
 
 spec :: Spec
-spec = beforeAll setup $ do
+spec = beforeAll setup $ afterAll tearDown $ do
 
   describe "basic operations" $ do
     it "inserts and counts entries" $ \(env, db) ->

--- a/test/Harness.hs
+++ b/test/Harness.hs
@@ -1,6 +1,7 @@
 
 module Harness
   ( setup
+  , tearDown
   ) where
 
 import Database.LMDB.Simple
@@ -17,3 +18,6 @@ setup = do
     return db
 
   return (env, db)
+
+tearDown :: (Environment ReadWrite, Database Int String) -> IO ()
+tearDown (env, _db) = closeEnvironment env


### PR DESCRIPTION
This PR adds the `closeEnvironment` function to `Database.LMDB.Simple`.

Not only this gives the user more control over the `Environment`, it is useful to close it specially in tests, so one can avoid the `too many open files` error when testing.

By the way, thanks for your effort in publishing this nice library! :smiley: :beers: 